### PR TITLE
Add priorityClassName tests for default values

### DIFF
--- a/test/extended/testdata/priority-class-name/system-cluster-critical.yaml
+++ b/test/extended/testdata/priority-class-name/system-cluster-critical.yaml
@@ -1,0 +1,16 @@
+kind: Template
+apiVersion: template.openshift.io/v1
+metadata:
+  name: template
+objects:
+- kind: Pod
+  apiVersion: v1
+  metadata:
+    name: pod-with-system-cluster-critical-priority-class
+  spec:
+    containers:
+    - name: new-container
+      image: busybox
+      command:
+      - ls
+    priorityClassName: system-cluster-critical

--- a/test/extended/testdata/priority-class-name/system-node-critical.yaml
+++ b/test/extended/testdata/priority-class-name/system-node-critical.yaml
@@ -1,0 +1,16 @@
+kind: Template
+apiVersion: template.openshift.io/v1
+metadata:
+  name: template
+objects:
+- kind: Pod
+  apiVersion: v1
+  metadata:
+    name: pod-with-system-node-critical-priority-class
+  spec:
+    containers:
+    - name: new-container
+      image: busybox
+      command:
+      - ls
+    priorityClassName: system-node-critical

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1947,6 +1947,10 @@ var Annotations = map[string]string{
 
 	"[sig-node] Managed cluster should verify that nodes have no unexpected reboots [Late]": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-node] Pod priority should match the default priorityClassName values system-cluster-critical=2000000000": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-node] Pod priority should match the default priorityClassName values system-node-critical=2000001000": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-node] [Conformance] Prevent openshift node labeling on update by the node TestOpenshiftNodeLabeling": " [Suite:openshift/conformance/parallel/minimal]",
 
 	"[sig-node] [FeatureGate:ImageVolume] ImageVolume should fail when image does not exist": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
Because of the issue described here: https://github.com/kubernetes/kubernetes/issues/133442

We are setting the priority field on static pods in the PRs:
https://github.com/openshift/cluster-etcd-operator/pull/1476
https://github.com/openshift/cluster-kube-scheduler-operator/pull/572
https://github.com/openshift/cluster-kube-apiserver-operator/pull/1915
https://github.com/openshift/cluster-kube-controller-manager-operator/pull/865

To do this, we need to have a test which verifies that the expected values for priority are in line with the priorityClassName